### PR TITLE
fix reloading entry due to missing parameter to hub.stop method

### DIFF
--- a/custom_components/victron_mqtt/__init__.py
+++ b/custom_components/victron_mqtt/__init__.py
@@ -80,5 +80,5 @@ async def async_unload_entry(
     _LOGGER.info("async_unload_entry called for entry: %s", entry.entry_id)
     hub: Hub = entry.runtime_data
     if hub is not None:
-        await hub.stop()
+        await hub.stop(None)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)


### PR DESCRIPTION
## Context

When reloading a config entry (a hub) there is an unknown error

## Description

When a config entry is reloaded, the following error appears in the logs:

```shell
Error unloading entry Cerbo GX (xxxxxxxxx) for victron_mqtt

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 963, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/victron_mqtt/__init__.py", line 83, in async_unload_entry
    await hub.stop()
          ~~~~~~~~^^
TypeError: Hub.stop() missing 1 required positional argument: 'event'
```

The `stop` method expects indeed an `event` parameter:

https://github.com/tomer-w/ha-victron-mqtt/blob/171c665b1df54cc094e68167fe9fe5ffdfc25c42/custom_components/victron_mqtt/hub.py#L81

This PR passes `None` as the `event` to `hub#stop` to avoid that error and allowing reloading entries.
I'm uncertain of what's the intention of that parameter and if it's really needed. Let me know if you consider it should be removed.

