### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,4 +1,6 @@
 name: Validate
+permissions:
+  contents: read
 
 on:
   push: 


### PR DESCRIPTION
Potential fix for [https://github.com/tomer-w/ha-victron-mqtt/security/code-scanning/2](https://github.com/tomer-w/ha-victron-mqtt/security/code-scanning/2)

To address the issue, add a `permissions` block to the workflow file, limiting the `GITHUB_TOKEN` permissions to the minimum required. Since both jobs only perform validation and use existing actions without writing to the repository or opening/modifying pull requests or issues, the minimal permissions (`contents: read`) are sufficient. This block should be added at the root level (top of the file, under the `name:` but above `on:`) so it applies to all jobs unless overridden. This does not affect existing functionality and ensures the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
