### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,4 +1,6 @@
 name: Validate
+permissions:
+  contents: read
 
 on:
   push: 


### PR DESCRIPTION
Potential fix for [https://github.com/tomer-w/ha-victron-mqtt/security/code-scanning/1](https://github.com/tomer-w/ha-victron-mqtt/security/code-scanning/1)

To fix this problem, we should add a top-level `permissions` block to the workflow YAML file (.github/workflows/validate.yaml). This block should be placed at the root of the file, underneath the `name:` line but before `on:` or `jobs:`. For validation workflows such as this, `contents: read` is usually the minimal and recommended permission, unless more privileges are specifically needed. No changes need to be made to the existing jobs or steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
