### PR TITLE
Fix typo in GRID_TO_BATTERY_RESTRICTED name

### DIFF
--- a/victron_mqtt.json
+++ b/victron_mqtt.json
@@ -6829,7 +6829,7 @@
         },
         {
           "id": "GRID_TO_BATTERY_RESTRICTED",
-          "name": "Grid to battey energy flow restricted",
+          "name": "Grid to battery energy flow restricted",
           "value": 1
         },
         {


### PR DESCRIPTION
Fixes a small typo in one of the DESSRestrictions.