### PR TITLE
Set solarcharger_device_off_reason as diagnostic and default disabled

### DIFF
--- a/custom_components/victron_mqtt/const.py
+++ b/custom_components/victron_mqtt/const.py
@@ -37,5 +37,5 @@ SWITCH_ON = "On"
 SWITCH_OFF = "Off"
 
 # Entity IDs which needs special treatment
-ENTITIES_CATEGORY_DIAGNOSTIC = ["system_heartbeat"]
-ENTITIES_DISABLE_BY_DEFAULT = ["system_heartbeat"]
+ENTITIES_CATEGORY_DIAGNOSTIC = ["system_heartbeat", "solarcharger_device_off_reason"]
+ENTITIES_DISABLE_BY_DEFAULT = ["system_heartbeat", "solarcharger_device_off_reason"]


### PR DESCRIPTION
This entity is more of a diagnostic kind of value and will not be relevant to most users of the integration. Therefore I think it is better to create it as a diagnostic type and as default disabled.