### PR TITLE
Fix entities unavailable with 2026.6.3

### DIFF
--- a/custom_components/victron_mqtt/sensor.py
+++ b/custom_components/victron_mqtt/sensor.py
@@ -123,7 +123,7 @@ class VictronSensor(VictronBaseEntity, RestoreSensor):
         """Return the unit of measurement."""
         if self._attr_device_class == SensorDeviceClass.MONETARY:
             return self.hass.config.currency
-        return self._attr_native_unit_of_measurement
+        return getattr(self, '_attr_native_unit_of_measurement', None)
 
     @callback
     def _on_update_cb(self, value: Any) -> None:


### PR DESCRIPTION
Note: fixed with Claude. Tested on my HA instance and looking good.

Update sensor.py

fixes: https://github.com/tomer-w/ha-victron-mqtt/issues/439 , https://github.com/tomer-w/ha-victron-mqtt/issues/438 , https://github.com/tomer-w/ha-victron-mqtt/issues/430 and possibly https://github.com/tomer-w/ha-victron-mqtt/issues/437

