### PR TITLE
feat: disable per-tracker/MPPT entities by default

### DIFF
--- a/custom_components/victron_mqtt/entity.py
+++ b/custom_components/victron_mqtt/entity.py
@@ -17,7 +17,28 @@ from homeassistant.helpers.entity import Entity
 # Entities that should be marked as diagnostic
 ENTITIES_CATEGORY_DIAGNOSTIC = ["system_heartbeat", "solarcharger_device_off_reason"]
 # Entities that should be disabled by default
-ENTITIES_DISABLE_BY_DEFAULT = ["system_heartbeat", "solarcharger_device_off_reason"]
+ENTITIES_DISABLE_BY_DEFAULT = [
+    "system_heartbeat",
+    "solarcharger_device_off_reason",
+    # Per-tracker solarcharger entities — multiply quickly on multi-tracker chargers
+    # (e.g. RS 450/200 = 4 trackers × 8 entities = 32 extra recorded entities per charger).
+    # Enabled individually by users who need the per-string breakdown.
+    "solarcharger_tracker_{tracker}_power",
+    "solarcharger_tracker_{tracker}_voltage",
+    "solarcharger_tracker_{tracker}_current",
+    "solarcharger_tracker_{tracker}_operation_mode",
+    "solarcharger_tracker_{tracker}_name",
+    "solarcharger_tracker_{tracker}_max_power_today",
+    "solarcharger_tracker_{tracker}_max_voltage_today",
+    "solarcharger_tracker_{tracker}_yield_today",
+    # Per-MPPT multi-device entities — same reason
+    "multi_mppt_{mppt_id}_yield_today",
+    "multi_mppt_{mppt_id}_yield_yesterday",
+    "multi_mppt_{mpptnumber}_state",
+    "multi_mppt_{mpptnumber}_power",
+    "multi_mppt_{mpptnumber}_voltage",
+    "multi_mppt_{mpptnumber}_current",
+]
 # Units that must be provided directly instead of via localization.
 SPECIAL_NATIVE_UNITS = {"%", "Ah"}
 


### PR DESCRIPTION
Follows up on tomer-w/victron_mqtt#103 (Q1).

Multi-tracker chargers (e.g. SmartSolar MPPT RS 450/200 with 4 PV trackers) produce ~8 per-tracker entities each, all updating on every keepalive cycle. On installations with several such chargers this easily adds up to dozens of continuously-recorded entities that most users never look at — device-level totals cover the common case.

**What this PR does:**

Adds 14 per-tracker / per-MPPT `generic_short_id`s to the existing `ENTITIES_DISABLE_BY_DEFAULT` list in `entity.py`:

- **solarcharger** (8): `tracker_{n}_power/voltage/current/operation_mode/name/max_power_today/max_voltage_today/yield_today`
- **multi** (6): `mppt_{n}_yield_today/yield_yesterday/state/power/voltage/current`

**Safe for existing installations:**

`entity_registry_enabled_default` only affects entities that don't yet exist in the registry. Any entity already registered keeps its current enabled/disabled state — no history, no automations, no `unique_id`s are affected.

Users who want the per-tracker breakdown can enable the entities individually in HA (Settings → Entities → show disabled).