### PR TITLE
refactor(entity): drop explicit entity_id override in complex naming

### DIFF
--- a/custom_components/victron_mqtt/entity.py
+++ b/custom_components/victron_mqtt/entity.py
@@ -68,8 +68,6 @@ class VictronBaseEntity(Entity):
             entity_id = f"{entity_platform}.{ENTITY_PREFIX}_{metric.unique_id}"
         else:
             entity_id = f"{entity_platform}.{ENTITY_PREFIX}_{installation_id}_{metric.unique_id}"
-            # you have to set the entity_id if we want to make the unique_id different from the default entity_id generation (which is based on the entity name)
-            self.entity_id = entity_id
         self._attr_unique_id = entity_id
         self._attr_suggested_display_precision = metric.precision
         # Always set translation_key so HA can resolve state/option translations (e.g. select options).

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -376,13 +376,8 @@ async def test_sensor_complex(
     )
 
     assert len(entities) == 2
-    simple_naming = mock_config_entry.data[CONF_SIMPLE_NAMING]
-    if simple_naming:
-        day_entity_id = "select.victron_venus_ess_batterylife_schedule_charge_2_days"
-        enabled_entity_id = "switch.victron_venus_ess_batterylife_schedule_charge_2_enabled"
-    else:
-        day_entity_id = "select.victron_mqtt_123_system_0_system_ess_schedule_charge_2_days"
-        enabled_entity_id = "switch.victron_mqtt_123_system_0_system_ess_schedule_charge_2_enabled"
+    day_entity_id = "select.victron_venus_ess_batterylife_schedule_charge_2_days"
+    enabled_entity_id = "switch.victron_venus_ess_batterylife_schedule_charge_2_enabled"
 
     day_entity = next(entity for entity in entities if entity.entity_id == day_entity_id)
     enabled_entity = next(
@@ -677,14 +672,7 @@ async def test_sensor_with_baseline(
     # Mock time.monotonic() to return a fixed time
     mock_time.return_value = 0
     
-    # The entity_id depends on the naming convention:
-    # simple_naming: HA generates from device name + entity name
-    # complex_naming: includes installation_id in the unique_id/entity_id
-    simple_naming = mock_config_entry.data[CONF_SIMPLE_NAMING]
-    if simple_naming:
-        entity_id = "sensor.victron_venus_pv_energy"
-    else:
-        entity_id = "sensor.victron_mqtt_123_system_0_system_dc_pv_energy"
+    entity_id = "sensor.victron_venus_pv_energy"
     
     # Mock the restore cache with a previous state value of 1000.0
     mock_restore_cache(hass, [State(entity_id, "1000.0")])
@@ -711,13 +699,8 @@ async def test_sensor_with_baseline(
     assert state is not None
     assert float(state.state) == 1000.004
     assert len(entities) == 2
-    simple_naming = mock_config_entry.data[CONF_SIMPLE_NAMING]
-    if simple_naming:
-        energy_entity_id = "sensor.victron_venus_pv_energy"
-        power_entity_id = "sensor.victron_venus_pv_power"
-    else:
-        energy_entity_id = "sensor.victron_mqtt_123_system_0_system_dc_pv_energy"
-        power_entity_id = "sensor.victron_mqtt_123_system_0_system_dc_pv_power"
+    energy_entity_id = "sensor.victron_venus_pv_energy"
+    power_entity_id = "sensor.victron_venus_pv_power"
 
     energy_entity = next(entity for entity in entities if entity.entity_id == energy_entity_id)
     energy_state = hass.states.get(energy_entity.entity_id)


### PR DESCRIPTION
You noted in the review that setting `self.entity_id` in complex naming was probably a mistake — the pattern from before proper HA entity naming was established. This PR just removes it.

**What changed:**
- Drop the two lines that explicitly set `self.entity_id` in the complex-naming branch.  
- HA now derives the entity_id from the entity name, the same way simple naming works.

**Why this is safe:**
- `unique_id` is unchanged, so existing entities keep their already-registered entity_id (HA stores it in the entity registry; the `unique_id` is just the lookup key).
- `DEFAULT_SIMPLE_NAMING = True`, so new installations already use simple naming and never hit this path.
- Complex naming users with new entities (new device added to an existing install) get HA-derived entity_ids going forward — cleaner and consistent with simple naming.

**No library changes needed** — `display_id` / `victron_mqtt` library not touched.