### PR TITLE
Fix boot race: retry on any startup error and clean up paho threads

### DIFF
--- a/custom_components/victron_mqtt/_vendor/victron_mqtt/hub.py
+++ b/custom_components/victron_mqtt/_vendor/victron_mqtt/hub.py
@@ -211,7 +211,6 @@ class Hub:
         self._fallback_placeholders: dict[str, FallbackPlaceholder] = {}
         self._all_metrics: dict[str, Metric] = {}
         self._first_connect = True
-        self._subscribed = False
         self._first_full_publish = True
         self._notified_device_ids: set[str] = set()
         self._connect_failed_attempts = 0
@@ -368,14 +367,21 @@ class Hub:
 
         _LOGGER.info("Starting paho mqtt")
         self._client.loop_start()
-        _LOGGER.info("Connecting")
-        self._client.connect_async(self.host, self.port)
-        _LOGGER.info("Waiting for connection event")
-        await self._wait_for_connect()
-        if self._connect_failed_reason is not None:
-            reraise_same_exception(self._connect_failed_reason)
-        _LOGGER.info("Successfully connected to MQTT broker at %s:%d", self.host, self.port)
-        await self._wait_for_installation_id(expected_id=self._expected_installation_id)
+        try:
+            _LOGGER.info("Connecting")
+            self._client.connect_async(self.host, self.port)
+            _LOGGER.info("Waiting for connection event")
+            await self._wait_for_connect()
+            if self._connect_failed_reason is not None:
+                reraise_same_exception(self._connect_failed_reason)
+            _LOGGER.info("Successfully connected to MQTT broker at %s:%d", self.host, self.port)
+            await self._wait_for_installation_id(expected_id=self._expected_installation_id)
+        except Exception:
+            # If anything fails after loop_start(), stop the paho thread to avoid leaking it.
+            # On HA retry a new Hub and paho client will be created.
+            _LOGGER.info("Connection setup failed, stopping paho mqtt loop")
+            self._client.loop_stop()
+            raise
         assert self._installation_id is not None
         # First we need to replace the installation ID in the subscription topics
         new_list: list[str] = []
@@ -415,24 +421,12 @@ class Hub:
         reason_code: ReasonCode,
         properties: Properties | None = None,
     ) -> None:
-        # Capture before _on_connect_internal changes it so we can distinguish
-        # first connect (where we must surface errors) from auto-reconnect
-        # (where we must NOT call disconnect, or paho stops retrying).
-        is_initial_connect = self._first_connect
         try:
             self._on_connect_internal(client, userdata, flags, reason_code, properties)
         except Exception as exc:
             _LOGGER.exception("_on_connect exception %s: %s", type(exc), exc)
-            if is_initial_connect:
-                # First connect: propagate the error so the caller can handle it
-                self._connect_failed_reason = exc
-                client.disconnect()
-            else:
-                # Reconnect: do NOT disconnect — let paho keep auto-reconnecting.
-                # Subscriptions will be retried from the keepalive loop.
-                _LOGGER.warning(
-                    "Subscription setup failed during reconnect, will retry from keepalive loop"
-                )
+            self._connect_failed_reason = exc
+            client.disconnect()
 
         try:
             self._schedule_threadsafe(self._connected_event.set)
@@ -464,14 +458,7 @@ class Hub:
                 f"Failed to connect to MQTT broker: {self.host}:{self.port}. Error: {connack_string(reason_code)}"
             )
 
-        is_reconnect = not self._first_connect
-        if is_reconnect:
-            _LOGGER.info(
-                "Reconnected to MQTT broker (session_present=%s). Re-establishing subscriptions...",
-                flags.session_present,
-            )
-        else:
-            _LOGGER.info("Connected to MQTT broker successfully")
+        _LOGGER.info("Connected to MQTT broker successfully")
         self._setup_subscriptions()
 
     def _on_disconnect(
@@ -483,7 +470,6 @@ class Hub:
         _properties: Properties | None = None,
     ) -> None:
         """Handle disconnection callback."""
-        self._subscribed = False
         if reason_code != 0:
             _LOGGER.warning(
                 "Unexpected disconnection from MQTT broker. Error: %s. flags: %s, Reconnecting...",
@@ -839,6 +825,7 @@ class Hub:
         self._stop_keepalive_loop()
         await asyncio.sleep(0.1)
         self._client.disconnect()  # need to call disconnect so the paho thread will terminate
+        self._client.loop_stop()   # stop the background thread started by loop_start()
         _LOGGER.info("Disconnected from MQTT broker")
         # Give a small delay to allow any pending MQTT messages to be processed
         await asyncio.sleep(0.1)
@@ -873,15 +860,6 @@ class Hub:
         count = 0
         while True:
             try:
-                # If subscriptions were lost (e.g. failed during reconnect), retry them
-                if not self._subscribed and self._client is not None and self._client.is_connected():
-                    _LOGGER.info("Subscriptions not established, retrying subscription setup...")
-                    try:
-                        self._setup_subscriptions()
-                        _LOGGER.info("Subscription retry succeeded")
-                    except Exception as sub_exc:
-                        _LOGGER.warning("Subscription retry failed, will try again: %s", sub_exc)
-
                 self._keepalive()
                 await asyncio.sleep(30)
                 # We should keep alive all metrics every 60 seconds
@@ -1070,7 +1048,6 @@ class Hub:
         assert self.installation_id is not None
         self._subscribe(f"N/{self.installation_id}/full_publish_completed")
         _LOGGER.info("Subscribed to full_publish_completed notification")
-        self._subscribed = True
         self._keepalive(True)
 
     async def _wait_for_connect(self) -> None:

--- a/custom_components/victron_mqtt/_vendor/victron_mqtt/hub.py
+++ b/custom_components/victron_mqtt/_vendor/victron_mqtt/hub.py
@@ -211,6 +211,7 @@ class Hub:
         self._fallback_placeholders: dict[str, FallbackPlaceholder] = {}
         self._all_metrics: dict[str, Metric] = {}
         self._first_connect = True
+        self._subscribed = False
         self._first_full_publish = True
         self._notified_device_ids: set[str] = set()
         self._connect_failed_attempts = 0
@@ -414,12 +415,24 @@ class Hub:
         reason_code: ReasonCode,
         properties: Properties | None = None,
     ) -> None:
+        # Capture before _on_connect_internal changes it so we can distinguish
+        # first connect (where we must surface errors) from auto-reconnect
+        # (where we must NOT call disconnect, or paho stops retrying).
+        is_initial_connect = self._first_connect
         try:
             self._on_connect_internal(client, userdata, flags, reason_code, properties)
         except Exception as exc:
             _LOGGER.exception("_on_connect exception %s: %s", type(exc), exc)
-            self._connect_failed_reason = exc
-            client.disconnect()
+            if is_initial_connect:
+                # First connect: propagate the error so the caller can handle it
+                self._connect_failed_reason = exc
+                client.disconnect()
+            else:
+                # Reconnect: do NOT disconnect — let paho keep auto-reconnecting.
+                # Subscriptions will be retried from the keepalive loop.
+                _LOGGER.warning(
+                    "Subscription setup failed during reconnect, will retry from keepalive loop"
+                )
 
         try:
             self._schedule_threadsafe(self._connected_event.set)
@@ -451,7 +464,14 @@ class Hub:
                 f"Failed to connect to MQTT broker: {self.host}:{self.port}. Error: {connack_string(reason_code)}"
             )
 
-        _LOGGER.info("Connected to MQTT broker successfully")
+        is_reconnect = not self._first_connect
+        if is_reconnect:
+            _LOGGER.info(
+                "Reconnected to MQTT broker (session_present=%s). Re-establishing subscriptions...",
+                flags.session_present,
+            )
+        else:
+            _LOGGER.info("Connected to MQTT broker successfully")
         self._setup_subscriptions()
 
     def _on_disconnect(
@@ -463,6 +483,7 @@ class Hub:
         _properties: Properties | None = None,
     ) -> None:
         """Handle disconnection callback."""
+        self._subscribed = False
         if reason_code != 0:
             _LOGGER.warning(
                 "Unexpected disconnection from MQTT broker. Error: %s. flags: %s, Reconnecting...",
@@ -852,6 +873,15 @@ class Hub:
         count = 0
         while True:
             try:
+                # If subscriptions were lost (e.g. failed during reconnect), retry them
+                if not self._subscribed and self._client is not None and self._client.is_connected():
+                    _LOGGER.info("Subscriptions not established, retrying subscription setup...")
+                    try:
+                        self._setup_subscriptions()
+                        _LOGGER.info("Subscription retry succeeded")
+                    except Exception as sub_exc:
+                        _LOGGER.warning("Subscription retry failed, will try again: %s", sub_exc)
+
                 self._keepalive()
                 await asyncio.sleep(30)
                 # We should keep alive all metrics every 60 seconds
@@ -1040,6 +1070,7 @@ class Hub:
         assert self.installation_id is not None
         self._subscribe(f"N/{self.installation_id}/full_publish_completed")
         _LOGGER.info("Subscribed to full_publish_completed notification")
+        self._subscribed = True
         self._keepalive(True)
 
     async def _wait_for_connect(self) -> None:

--- a/custom_components/victron_mqtt/hub.py
+++ b/custom_components/victron_mqtt/hub.py
@@ -118,7 +118,7 @@ class Hub:
             raise ConfigEntryAuthFailed(
                 f"Authentication failed for {self.host}: {auth_error}"
             ) from auth_error
-        except CannotConnectError as connect_error:
+        except Exception as connect_error:
             raise ConfigEntryNotReady(
                 f"Cannot connect to the hub: {connect_error}"
             ) from connect_error


### PR DESCRIPTION
## Problem

Fixes #461

When HA and the Victron system boot simultaneously after a power outage (no UPS), the integration can fail permanently and never recover until manually reloaded.

## Root Cause

`Hub.start()` only catches `CannotConnectError` and `AuthenticationError`. But during the boot race, `connect()` can raise other exceptions (e.g. `NotConnectedError` if the connection drops mid-setup, or `AssertionError`, etc.). Any uncaught exception causes HA to treat the failure as **permanent** — no retry.

Additionally, `connect()` starts a paho background thread via `loop_start()` early in the setup. If any later step fails, the thread is leaked (no `loop_stop()` call). Each HA retry creates a new Hub, leaking another thread.

## Fix (3 minimal changes)

1. **`Hub.start()`**: `except CannotConnectError` → `except Exception` — any startup error (except auth) becomes `ConfigEntryNotReady`, so HA retries with exponential backoff
2. **`connect()`**: Wrap post-`loop_start()` code in try/except that calls `loop_stop()` on failure — prevents leaked paho threads on retry
3. **`disconnect()`**: Add `loop_stop()` — properly stops the background thread