### PR TITLE
Improve GX device config flow

### DIFF
--- a/custom_components/victron_mqtt/config_flow.py
+++ b/custom_components/victron_mqtt/config_flow.py
@@ -6,8 +6,6 @@ from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlparse
 
-import aiohttp
-
 from ._vendor.victron_mqtt import (
     AuthenticationError,
     CannotConnectError,
@@ -444,14 +442,11 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
                 credentials: PairingToken = await request_pairing_token(
                     self.hostname, self.installation_id
                 )
-            except (aiohttp.ClientError, TimeoutError):
-                _LOGGER.exception("Failed to connect to GX device for token pairing")
-                errors["base"] = "cannot_connect"
             except PairingError:
                 errors["base"] = "pairing_failed"
             except Exception:
-                _LOGGER.exception("Unexpected error during token pairing")
-                errors["base"] = "unknown"
+                _LOGGER.exception("Failed to connect to GX device for token pairing")
+                errors["base"] = "cannot_connect"
             else:
                 data: dict[str, Any] = {
                     CONF_HOST: self.hostname,

--- a/custom_components/victron_mqtt/config_flow.py
+++ b/custom_components/victron_mqtt/config_flow.py
@@ -33,7 +33,6 @@ from homeassistant.const import (
     CONF_SSL,
     CONF_USERNAME,
 )
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.selector import (
     SelectOptionDict,
     SelectSelector,
@@ -442,9 +441,8 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                session = async_create_clientsession(self.hass, verify_ssl=False)
                 credentials: PairingToken = await request_pairing_token(
-                    self.hostname, self.installation_id, session
+                    self.hostname, self.installation_id
                 )
             except (aiohttp.ClientError, TimeoutError):
                 _LOGGER.exception("Failed to connect to GX device for token pairing")

--- a/custom_components/victron_mqtt/config_flow.py
+++ b/custom_components/victron_mqtt/config_flow.py
@@ -48,7 +48,6 @@ from .const import (
     CONF_EXCLUDED_DEVICES,
     CONF_INSTALLATION_ID,
     CONF_MODEL,
-    CONF_MQTT_TOKEN_PAIRING,
     CONF_OPERATION_MODE,
     CONF_ROOT_TOPIC_PREFIX,
     CONF_SERIAL,
@@ -378,8 +377,6 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_SSL: True,
                 CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
             }
-            if self.mqtt_token_pairing:
-                data[CONF_MQTT_TOKEN_PAIRING] = True
             try:
                 await validate_input(data)
             except AuthenticationError:
@@ -468,7 +465,6 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_PASSWORD: credentials.password,
                     CONF_SSL: True,
                     CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
-                    CONF_MQTT_TOKEN_PAIRING: True,
                 }
                 try:
                     await validate_input(data)
@@ -522,9 +518,6 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_SSL: user_input.get(CONF_SSL, True),
                 CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
             }
-            if self.mqtt_token_pairing:
-                data[CONF_MQTT_TOKEN_PAIRING] = True
-
             try:
                 await validate_input(data)
             except AuthenticationError:

--- a/custom_components/victron_mqtt/config_flow.py
+++ b/custom_components/victron_mqtt/config_flow.py
@@ -13,7 +13,10 @@ from ._vendor.victron_mqtt import (
     CannotConnectError,
     DeviceType,
     Hub as VictronVenusHub,
-    OperationMode
+    OperationMode,
+    PairingError,
+    PairingToken,
+    request_pairing_token,
 )
 import voluptuous as vol
 
@@ -65,10 +68,6 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
-
-
-class PairingError(Exception):
-    """Raised when token pairing with the GX device fails."""
 
 
 ENTRY_TITLE_FORMAT = "Victron OS {installation_id} ({host}:{port})"
@@ -446,7 +445,10 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                credentials = await self._request_pairing_token()
+                session = async_create_clientsession(self.hass, verify_ssl=False)
+                credentials: PairingToken = await request_pairing_token(
+                    self.hostname, self.installation_id, session
+                )
             except (aiohttp.ClientError, TimeoutError):
                 _LOGGER.exception("Failed to connect to GX device for token pairing")
                 errors["base"] = "cannot_connect"
@@ -462,8 +464,8 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_SERIAL: self.serial,
                     CONF_INSTALLATION_ID: self.installation_id,
                     CONF_MODEL: self.model_name,
-                    CONF_USERNAME: credentials["token_name"],
-                    CONF_PASSWORD: credentials["password"],
+                    CONF_USERNAME: credentials.token_name,
+                    CONF_PASSWORD: credentials.password,
                     CONF_SSL: True,
                     CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
                     CONF_MQTT_TOKEN_PAIRING: True,
@@ -494,29 +496,6 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={CONF_HOST: self.hostname},
         )
-
-    async def _request_pairing_token(self) -> dict[str, str]:
-        """Request pairing credentials from the GX device via HTTPS."""
-        session = async_create_clientsession(self.hass, verify_ssl=False)
-        url = f"https://{self.hostname}/auth/generate-token/"
-        resp = await session.post(
-            url,
-            data={
-                "role": "homeassistant",
-                "device_id": self.installation_id,
-            },
-        )
-        if resp.status != 200:
-            body = await resp.text()
-            _LOGGER.error(
-                "Token pairing request failed (HTTP %s): %s", resp.status, body
-            )
-            raise PairingError
-        result: dict[str, str] = await resp.json(content_type=None)
-        _LOGGER.debug(
-            "Token pairing successful, token_name=%s", result.get("token_name")
-        )
-        return result
 
     async def async_step_ssdp_auth(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/victron_mqtt/config_flow.py
+++ b/custom_components/victron_mqtt/config_flow.py
@@ -6,6 +6,8 @@ from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlparse
 
+import aiohttp
+
 from ._vendor.victron_mqtt import (
     AuthenticationError,
     CannotConnectError,
@@ -28,6 +30,7 @@ from homeassistant.const import (
     CONF_SSL,
     CONF_USERNAME,
 )
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.selector import (
     SelectOptionDict,
     SelectSelector,
@@ -42,6 +45,7 @@ from .const import (
     CONF_EXCLUDED_DEVICES,
     CONF_INSTALLATION_ID,
     CONF_MODEL,
+    CONF_MQTT_TOKEN_PAIRING,
     CONF_OPERATION_MODE,
     CONF_ROOT_TOPIC_PREFIX,
     CONF_SERIAL,
@@ -61,6 +65,11 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
+
+
+class PairingError(Exception):
+    """Raised when token pairing with the GX device fails."""
+
 
 ENTRY_TITLE_FORMAT = "Victron OS {installation_id} ({host}:{port})"
 DEFAULT_SSL_PORT = 8883
@@ -148,9 +157,8 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 STEP_SSDP_AUTH_DATA_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_USERNAME, default=""): str,
         vol.Optional(CONF_PASSWORD, default=""): str,
-        vol.Optional(CONF_SSL, default=False): bool,
+        vol.Optional(CONF_SSL, default=True): bool,
     }
 )
 
@@ -200,6 +208,7 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
         self.installation_id: str | None = None
         self.friendly_name: str | None = None
         self.model_name: str | None = None
+        self.mqtt_token_pairing: bool = False
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -327,13 +336,15 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
         self.installation_id = discovery_info.upnp["X_VrmPortalId"]
         self.model_name = discovery_info.upnp["modelName"]
         self.friendly_name = discovery_info.upnp["friendlyName"]
+        self.mqtt_token_pairing = discovery_info.upnp.get("X_MqttTokenPairing") == "1"
         _LOGGER.debug(
-            "SSDP: hostname=%s, serial=%s, installation_id=%s, model_name=%s, friendly_name=%s",
+            "SSDP: hostname=%s, serial=%s, installation_id=%s, model_name=%s, friendly_name=%s, mqtt_token_pairing=%s",
             self.hostname,
             self.serial,
             self.installation_id,
             self.model_name,
             self.friendly_name,
+            self.mqtt_token_pairing,
         )
 
         await self.async_set_unique_id(self.installation_id)
@@ -361,19 +372,40 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             data: dict[str, Any] = {
                 CONF_HOST: self.hostname,
-                CONF_PORT: DEFAULT_PORT,
+                CONF_PORT: DEFAULT_SSL_PORT,
                 CONF_SERIAL: self.serial,
                 CONF_INSTALLATION_ID: self.installation_id,
                 CONF_MODEL: self.model_name,
-                CONF_SSL: False,
+                CONF_SSL: True,
                 CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
             }
+            if self.mqtt_token_pairing:
+                data[CONF_MQTT_TOKEN_PAIRING] = True
             try:
                 await validate_input(data)
             except AuthenticationError:
+                if self.mqtt_token_pairing:
+                    return await self.async_step_ssdp_token_pairing()
                 return await self.async_step_ssdp_auth()
             except CannotConnectError:
-                return self.async_abort(reason="cannot_connect")
+                # SSL failed, fall back to plain MQTT on port 1883
+                data[CONF_PORT] = DEFAULT_PORT
+                data[CONF_SSL] = False
+                try:
+                    await validate_input(data)
+                except AuthenticationError:
+                    if self.mqtt_token_pairing:
+                        return await self.async_step_ssdp_token_pairing()
+                    return await self.async_step_ssdp_auth()
+                except CannotConnectError:
+                    if self.mqtt_token_pairing:
+                        return await self.async_step_ssdp_token_pairing()
+                    return self.async_abort(reason="cannot_connect")
+                except Exception:
+                    _LOGGER.exception(
+                        "Unexpected error validating SSDP discovery for Victron MQTT"
+                    )
+                    return self.async_abort(reason="unknown")
             except Exception:
                 _LOGGER.exception(
                     "Unexpected error validating SSDP discovery for Victron MQTT"
@@ -384,7 +416,7 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
                 title=build_title(
                     self.installation_id,
                     self.hostname,
-                    DEFAULT_PORT,
+                    data[CONF_PORT],
                     self.friendly_name,
                 ),
                 data=data,
@@ -403,6 +435,89 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_ssdp_token_pairing(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle automatic token pairing with the GX device."""
+        assert self.hostname is not None
+        assert self.installation_id is not None
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                credentials = await self._request_pairing_token()
+            except (aiohttp.ClientError, TimeoutError):
+                _LOGGER.exception("Failed to connect to GX device for token pairing")
+                errors["base"] = "cannot_connect"
+            except PairingError:
+                errors["base"] = "pairing_failed"
+            except Exception:
+                _LOGGER.exception("Unexpected error during token pairing")
+                errors["base"] = "unknown"
+            else:
+                data: dict[str, Any] = {
+                    CONF_HOST: self.hostname,
+                    CONF_PORT: DEFAULT_SSL_PORT,
+                    CONF_SERIAL: self.serial,
+                    CONF_INSTALLATION_ID: self.installation_id,
+                    CONF_MODEL: self.model_name,
+                    CONF_USERNAME: credentials["token_name"],
+                    CONF_PASSWORD: credentials["password"],
+                    CONF_SSL: True,
+                    CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
+                    CONF_MQTT_TOKEN_PAIRING: True,
+                }
+                try:
+                    await validate_input(data)
+                except AuthenticationError:
+                    errors["base"] = "invalid_auth"
+                except CannotConnectError:
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception("Unexpected error validating paired credentials")
+                    errors["base"] = "unknown"
+                else:
+                    return self.async_create_entry(
+                        title=build_title(
+                            self.installation_id,
+                            self.hostname,
+                            DEFAULT_SSL_PORT,
+                            self.friendly_name,
+                        ),
+                        data=data,
+                    )
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="ssdp_token_pairing",
+            errors=errors,
+            description_placeholders={CONF_HOST: self.hostname},
+        )
+
+    async def _request_pairing_token(self) -> dict[str, str]:
+        """Request pairing credentials from the GX device via HTTPS."""
+        session = async_create_clientsession(self.hass, verify_ssl=False)
+        url = f"https://{self.hostname}/auth/generate-token/"
+        resp = await session.post(
+            url,
+            data={
+                "role": "homeassistant",
+                "device_id": self.installation_id,
+            },
+        )
+        if resp.status != 200:
+            body = await resp.text()
+            _LOGGER.error(
+                "Token pairing request failed (HTTP %s): %s", resp.status, body
+            )
+            raise PairingError
+        result: dict[str, str] = await resp.json(content_type=None)
+        _LOGGER.debug(
+            "Token pairing successful, token_name=%s", result.get("token_name")
+        )
+        return result
+
     async def async_step_ssdp_auth(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -419,15 +534,17 @@ class VictronMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             data: dict[str, Any] = {
                 CONF_HOST: self.hostname,
-                CONF_PORT: default_port_for(user_input.get(CONF_SSL, False)),
+                CONF_PORT: default_port_for(user_input.get(CONF_SSL, True)),
                 CONF_SERIAL: self.serial,
                 CONF_INSTALLATION_ID: self.installation_id,
                 CONF_MODEL: self.model_name,
-                CONF_USERNAME: user_input.get(CONF_USERNAME) or None,
+                CONF_USERNAME: "remoteconsole",
                 CONF_PASSWORD: user_input.get(CONF_PASSWORD) or None,
-                CONF_SSL: user_input.get(CONF_SSL, False),
+                CONF_SSL: user_input.get(CONF_SSL, True),
                 CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
             }
+            if self.mqtt_token_pairing:
+                data[CONF_MQTT_TOKEN_PAIRING] = True
 
             try:
                 await validate_input(data)

--- a/custom_components/victron_mqtt/const.py
+++ b/custom_components/victron_mqtt/const.py
@@ -18,7 +18,6 @@ CONF_OPERATION_MODE = "operation_mode"
 CONF_EXCLUDED_DEVICES = "excluded_devices"
 CONF_SIMPLE_NAMING = "simple_naming"
 CONF_ELEVATED_TRACING = "elevated_tracing"
-CONF_MQTT_TOKEN_PAIRING = "mqtt_token_pairing"
 
 DEVICE_MESSAGE = "device"
 SENSOR_MESSAGE = "sensor"

--- a/custom_components/victron_mqtt/const.py
+++ b/custom_components/victron_mqtt/const.py
@@ -18,6 +18,7 @@ CONF_OPERATION_MODE = "operation_mode"
 CONF_EXCLUDED_DEVICES = "excluded_devices"
 CONF_SIMPLE_NAMING = "simple_naming"
 CONF_ELEVATED_TRACING = "elevated_tracing"
+CONF_MQTT_TOKEN_PAIRING = "mqtt_token_pairing"
 
 DEVICE_MESSAGE = "device"
 SENSOR_MESSAGE = "sensor"

--- a/custom_components/victron_mqtt/manifest.json
+++ b/custom_components/victron_mqtt/manifest.json
@@ -16,6 +16,10 @@
     {
       "manufacturer": "Victron Energy",
       "X_MqttOnLan": "1"
+    },
+    {
+      "manufacturer": "Victron Energy",
+      "X_MqttTokenPairing": "1"
     }
   ],
   "version": "2026.8.1"

--- a/custom_components/victron_mqtt/translations/ca.json
+++ b/custom_components/victron_mqtt/translations/ca.json
@@ -3,6 +3,7 @@
     "error": {
       "cannot_connect": "No s'ha pogut connectar a l'amfitrió",
       "invalid_auth": "Problema d'autenticació",
+      "pairing_failed": "L'emparellament ha fallat. Assegureu-vos que el mode d'emparellament estigui actiu al dispositiu GX i torneu-ho a provar.",
       "unknown": "Error desconegut"
     },
     "step": {
@@ -35,11 +36,14 @@
       },
       "ssdp_auth": {
         "data": {
-          "username": "Nom d'usuari",
-          "password": "Contrasenya",
+          "password": "Contrasenya GX",
           "ssl": "Usa SSL"
         },
-        "description": "Es requereix autenticació per a {host}."
+        "description": "Introduïu la **contrasenya GX** del dispositiu GX a {host}."
+      },
+      "ssdp_token_pairing": {
+        "title": "Emparellar amb el dispositiu GX",
+        "description": "Activeu el mode d'emparellament al dispositiu GX abans de prémer Enviar:\n\n- A la interfície del GX: **Configuració** > **Integracions** > **Dispositius MQTT** > **Mode d'emparellament**\n- En dispositius GX sense pantalla integrada: Premeu ràpidament dues vegades el botó integrat\n\nEl mode d'emparellament està actiu durant 120 segons."
       }
     }
   },

--- a/custom_components/victron_mqtt/translations/de.json
+++ b/custom_components/victron_mqtt/translations/de.json
@@ -3,6 +3,7 @@
     "error": {
       "cannot_connect": "Verbindung zum Host ist fehlgeschlagen",
       "invalid_auth": "Authentifizierungsfehler",
+      "pairing_failed": "Token-Pairing fehlgeschlagen. Stellen Sie sicher, dass der Pairing-Modus auf dem GX-Gerät aktiv ist, und versuchen Sie es erneut.",
       "unknown": "Unbekannter Fehler"
     },
     "step": {
@@ -35,11 +36,14 @@
       },
       "ssdp_auth": {
         "data": {
-          "username": "Benutzername",
-          "password": "Passwort",
+          "password": "GX-Passwort",
           "ssl": "SSL verwenden"
         },
-        "description": "Authentifizierung ist für {host} erforderlich."
+        "description": "Geben Sie das **GX-Passwort** für das GX-Gerät unter {host} ein."
+      },
+      "ssdp_token_pairing": {
+        "title": "Mit GX-Gerät koppeln",
+        "description": "Aktivieren Sie den Pairing-Modus auf dem GX-Gerät, bevor Sie auf Absenden klicken:\n\n- Über die GX-Benutzeroberfläche: **Einstellungen** > **Integrationen** > **MQTT-Geräte** > **Pairing-Modus**\n- Bei GX-Geräten ohne eingebauten Bildschirm: Drücken Sie schnell zweimal die eingebaute Taste\n\nDer Pairing-Modus ist 120 Sekunden lang aktiv."
       }
     }
   },

--- a/custom_components/victron_mqtt/translations/en.json
+++ b/custom_components/victron_mqtt/translations/en.json
@@ -3,19 +3,23 @@
     "error": {
       "cannot_connect": "Failed to connect to host",
       "invalid_auth": "Authentication issue",
+      "pairing_failed": "Token pairing failed. Ensure pairing mode is active on the GX device and try again.",
       "unknown": "Unknown failure"
     },
     "step": {
       "ssdp_auth": {
         "data": {
-          "password": "Password",
-          "ssl": "Use SSL",
-          "username": "Username"
+          "password": "GX Password",
+          "ssl": "Use SSL"
         },
-        "description": "Authentication is required for {host}."
+        "description": "Enter the **GX Password** for the GX device at {host}."
       },
       "ssdp_confirm": {
         "description": "Do you want to set up {name}?"
+      },
+      "ssdp_token_pairing": {
+        "title": "Pair with GX device",
+        "description": "Enable pairing mode on the GX device before pressing Submit:\n\n- Via GX user interface: **Settings** > **Integrations** > **MQTT Devices** > **Pairing mode**\n- On GX devices without a built-in screen: Quickly double-press the built-in button\n\nPairing mode is active for 120 seconds."
       },
       "user": {
         "data": {

--- a/custom_components/victron_mqtt/translations/fr.json
+++ b/custom_components/victron_mqtt/translations/fr.json
@@ -3,6 +3,7 @@
     "error": {
       "cannot_connect": "Échec de la connexion à l'hôte",
       "invalid_auth": "Problème d'authentification",
+      "pairing_failed": "L'appairage a échoué. Assurez-vous que le mode d'appairage est actif sur l'appareil GX et réessayez.",
       "unknown": "Échec inconnu"
     },
     "step": {
@@ -35,11 +36,14 @@
       },
       "ssdp_auth": {
         "data": {
-          "username": "Nom d'utilisateur",
-          "password": "Mot de passe",
+          "password": "Mot de passe GX",
           "ssl": "Utiliser SSL"
         },
-        "description": "Une authentification est requise pour {host}."
+        "description": "Entrez le **mot de passe GX** de l'appareil GX à {host}."
+      },
+      "ssdp_token_pairing": {
+        "title": "Appairer avec l'appareil GX",
+        "description": "Activez le mode d'appairage sur l'appareil GX avant de cliquer sur Envoyer :\n\n- Via l'interface du GX : **Paramètres** > **Intégrations** > **Appareils MQTT** > **Mode d'appairage**\n- Sur les appareils GX sans écran intégré : Appuyez rapidement deux fois sur le bouton intégré\n\nLe mode d'appairage est actif pendant 120 secondes."
       }
     }
   },

--- a/custom_components/victron_mqtt/translations/sk.json
+++ b/custom_components/victron_mqtt/translations/sk.json
@@ -3,6 +3,7 @@
     "error": {
       "cannot_connect": "Nepodarilo sa pripojiť k hostiteľovi",
       "invalid_auth": "Problém s autentifikáciou",
+      "pairing_failed": "Párovanie zlyhalo. Uistite sa, že je režim párovania na zariadení GX aktívny, a skúste to znova.",
       "unknown": "Neznáma chyba"
     },
     "step": {
@@ -39,11 +40,14 @@
       },
       "ssdp_auth": {
         "data": {
-          "username": "Používateľské meno",
-          "password": "Heslo",
+          "password": "Heslo GX",
           "ssl": "Použiť SSL"
         },
-        "description": "Pre {host} je potrebná autentifikácia."
+        "description": "Zadajte **heslo GX** pre zariadenie GX na {host}."
+      },
+      "ssdp_token_pairing": {
+        "title": "Spárovať so zariadením GX",
+        "description": "Pred stlačením Odoslať aktivujte režim párovania na zariadení GX:\n\n- Cez rozhranie GX: **Nastavenia** > **Integrácie** > **Zariadenia MQTT** > **Režim párovania**\n- Na zariadeniach GX bez vstavanej obrazovky: Rýchlo dvakrát stlačte vstavané tlačidlo\n\nRežim párovania je aktívny 120 sekúnd."
       }
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,7 +10,6 @@ from custom_components.victron_mqtt.config_flow import DEFAULT_SSL_PORT
 from custom_components.victron_mqtt.const import (
     CONF_EXCLUDED_DEVICES,
     CONF_INSTALLATION_ID,
-    CONF_MQTT_TOKEN_PAIRING,
     CONF_OPERATION_MODE,
     CONF_MODEL,
     CONF_ROOT_TOPIC_PREFIX,
@@ -1025,7 +1024,6 @@ async def test_ssdp_flow_with_mqtt_token_pairing(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_MQTT_TOKEN_PAIRING] is True
 
 
 @pytest.mark.usefixtures("mock_victron_hub")
@@ -1059,7 +1057,6 @@ async def test_ssdp_flow_without_mqtt_token_pairing(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert CONF_MQTT_TOKEN_PAIRING not in result["data"]
 
 
 @pytest.mark.usefixtures("mock_victron_hub")
@@ -1094,7 +1091,6 @@ async def test_ssdp_flow_mqtt_token_pairing_not_one(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert CONF_MQTT_TOKEN_PAIRING not in result["data"]
 
 
 async def test_ssdp_auth_flow_without_mqtt_token_pairing(
@@ -1145,7 +1141,6 @@ async def test_ssdp_auth_flow_without_mqtt_token_pairing(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert CONF_MQTT_TOKEN_PAIRING not in result["data"]
 
 
 async def test_ssdp_token_pairing_success(
@@ -1221,7 +1216,6 @@ async def test_ssdp_token_pairing_success(
         CONF_PASSWORD: "generatedSecretPassword",
         CONF_SSL: True,
         CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
-        CONF_MQTT_TOKEN_PAIRING: True,
     }
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 from custom_components.victron_mqtt._vendor.victron_mqtt import CannotConnectError, OperationMode
+from custom_components.victron_mqtt._vendor.victron_mqtt.pairing import PairingError, PairingToken
 from custom_components.victron_mqtt.config_flow import DEFAULT_SSL_PORT
 
 from custom_components.victron_mqtt.const import (
@@ -1184,21 +1185,12 @@ async def test_ssdp_token_pairing_success(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "ssdp_token_pairing"
 
-    mock_response = AsyncMock()
-    mock_response.status = 200
-    mock_response.json = AsyncMock(
-        return_value={
-            "token_name": "token/homeassistant/homeassistant_abc123",
-            "password": "generatedSecretPassword",
-        }
-    )
-
-    mock_session = AsyncMock()
-    mock_session.post = AsyncMock(return_value=mock_response)
-
     with patch(
-        "custom_components.victron_mqtt.config_flow.async_create_clientsession",
-        return_value=mock_session,
+        "custom_components.victron_mqtt.config_flow.request_pairing_token",
+        return_value=PairingToken(
+            token_name="token/homeassistant/homeassistant_abc123",
+            password="generatedSecretPassword",
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -1255,16 +1247,9 @@ async def test_ssdp_token_pairing_http_error(
 
     assert result["step_id"] == "ssdp_token_pairing"
 
-    mock_response = AsyncMock()
-    mock_response.status = 403
-    mock_response.text = AsyncMock(return_value="Pairing mode not active")
-
-    mock_session = AsyncMock()
-    mock_session.post = AsyncMock(return_value=mock_response)
-
     with patch(
-        "custom_components.victron_mqtt.config_flow.async_create_clientsession",
-        return_value=mock_session,
+        "custom_components.victron_mqtt.config_flow.request_pairing_token",
+        side_effect=PairingError("HTTP 403: Pairing mode not active"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -1312,12 +1297,9 @@ async def test_ssdp_token_pairing_connection_error(
 
     assert result["step_id"] == "ssdp_token_pairing"
 
-    mock_session = AsyncMock()
-    mock_session.post = AsyncMock(side_effect=aiohttp.ClientError("Connection refused"))
-
     with patch(
-        "custom_components.victron_mqtt.config_flow.async_create_clientsession",
-        return_value=mock_session,
+        "custom_components.victron_mqtt.config_flow.request_pairing_token",
+        side_effect=aiohttp.ClientError("Connection refused"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -1366,21 +1348,12 @@ async def test_ssdp_token_pairing_mqtt_connection_fails(
 
     assert result["step_id"] == "ssdp_token_pairing"
 
-    mock_response = AsyncMock()
-    mock_response.status = 200
-    mock_response.json = AsyncMock(
-        return_value={
-            "token_name": "token/homeassistant/ha_abc",
-            "password": "secret",
-        }
-    )
-
-    mock_session = AsyncMock()
-    mock_session.post = AsyncMock(return_value=mock_response)
-
     with patch(
-        "custom_components.victron_mqtt.config_flow.async_create_clientsession",
-        return_value=mock_session,
+        "custom_components.victron_mqtt.config_flow.request_pairing_token",
+        return_value=PairingToken(
+            token_name="token/homeassistant/ha_abc",
+            password="secret",
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from custom_components.victron_mqtt._vendor.victron_mqtt import CannotConnectError, OperationMode
 from custom_components.victron_mqtt.config_flow import DEFAULT_SSL_PORT
@@ -9,6 +10,7 @@ from custom_components.victron_mqtt.config_flow import DEFAULT_SSL_PORT
 from custom_components.victron_mqtt.const import (
     CONF_EXCLUDED_DEVICES,
     CONF_INSTALLATION_ID,
+    CONF_MQTT_TOKEN_PAIRING,
     CONF_OPERATION_MODE,
     CONF_MODEL,
     CONF_ROOT_TOPIC_PREFIX,
@@ -282,11 +284,11 @@ async def test_ssdp_flow_success(
     assert result["title"] == MOCK_FRIENDLY_NAME
     assert result["data"] == {
         CONF_HOST: MOCK_HOST,
-        CONF_PORT: DEFAULT_PORT,
+        CONF_PORT: DEFAULT_SSL_PORT,
         CONF_SERIAL: MOCK_SERIAL,
         CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
         CONF_MODEL: MOCK_MODEL,
-        CONF_SSL: False,
+        CONF_SSL: True,
         CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
     }
 
@@ -771,7 +773,6 @@ async def test_ssdp_auth_ssl_uses_ssl_port(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            CONF_USERNAME: "test-user",
             CONF_PASSWORD: "test-password",
             CONF_SSL: True,
         },
@@ -785,7 +786,7 @@ async def test_ssdp_auth_ssl_uses_ssl_port(
         CONF_SERIAL: MOCK_SERIAL,
         CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
         CONF_MODEL: MOCK_MODEL,
-        CONF_USERNAME: "test-user",
+        CONF_USERNAME: "remoteconsole",
         CONF_PASSWORD: "test-password",
         CONF_SSL: True,
         CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
@@ -987,3 +988,448 @@ async def test_migration_v2_to_v3_missing_frequency_becomes_auto(
     assert result is True
     assert mock_config_entry.data[CONF_UPDATE_FREQUENCY_MODE] == UPDATE_FREQUENCY_MODE_AUTO
     assert mock_config_entry.version == 3
+
+
+@pytest.mark.usefixtures("mock_victron_hub")
+async def test_ssdp_flow_with_mqtt_token_pairing(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test SSDP discovery with X_MqttTokenPairing=1 stores mqtt_token_pairing."""
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "X_MqttTokenPairing": "1",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MQTT_TOKEN_PAIRING] is True
+
+
+@pytest.mark.usefixtures("mock_victron_hub")
+async def test_ssdp_flow_without_mqtt_token_pairing(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test SSDP discovery without X_MqttTokenPairing does not set the key."""
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert CONF_MQTT_TOKEN_PAIRING not in result["data"]
+
+
+@pytest.mark.usefixtures("mock_victron_hub")
+async def test_ssdp_flow_mqtt_token_pairing_not_one(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test SSDP discovery with X_MqttTokenPairing != '1' does not set the key."""
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "X_MqttTokenPairing": "0",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert CONF_MQTT_TOKEN_PAIRING not in result["data"]
+
+
+async def test_ssdp_auth_flow_without_mqtt_token_pairing(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test SSDP auth flow without X_MqttTokenPairing omits mqtt_token_pairing from data."""
+    mock_victron_hub.return_value.connect.side_effect = AuthenticationError(
+        "Authentication required"
+    )
+
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_auth"
+
+    mock_victron_hub.return_value.connect.side_effect = None
+    mock_victron_hub.return_value.installation_id = MOCK_INSTALLATION_ID
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_PASSWORD: "test-password",
+            CONF_SSL: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert CONF_MQTT_TOKEN_PAIRING not in result["data"]
+
+
+async def test_ssdp_token_pairing_success(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test SSDP flow routes to token pairing and creates entry on success."""
+    mock_victron_hub.return_value.connect.side_effect = [
+        AuthenticationError("auth required"),
+        None,
+    ]
+
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "X_MqttTokenPairing": "1",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_token_pairing"
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "token_name": "token/homeassistant/homeassistant_abc123",
+            "password": "generatedSecretPassword",
+        }
+    )
+
+    mock_session = AsyncMock()
+    mock_session.post = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "custom_components.victron_mqtt.config_flow.async_create_clientsession",
+        return_value=mock_session,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_HOST: MOCK_HOST,
+        CONF_PORT: DEFAULT_SSL_PORT,
+        CONF_SERIAL: MOCK_SERIAL,
+        CONF_INSTALLATION_ID: MOCK_INSTALLATION_ID,
+        CONF_MODEL: MOCK_MODEL,
+        CONF_USERNAME: "token/homeassistant/homeassistant_abc123",
+        CONF_PASSWORD: "generatedSecretPassword",
+        CONF_SSL: True,
+        CONF_SIMPLE_NAMING: DEFAULT_SIMPLE_NAMING,
+        CONF_MQTT_TOKEN_PAIRING: True,
+    }
+
+
+async def test_ssdp_token_pairing_http_error(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test token pairing shows error when GX returns non-200 (pairing not active)."""
+    mock_victron_hub.return_value.connect.side_effect = AuthenticationError(
+        "auth required"
+    )
+
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "X_MqttTokenPairing": "1",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["step_id"] == "ssdp_token_pairing"
+
+    mock_response = AsyncMock()
+    mock_response.status = 403
+    mock_response.text = AsyncMock(return_value="Pairing mode not active")
+
+    mock_session = AsyncMock()
+    mock_session.post = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "custom_components.victron_mqtt.config_flow.async_create_clientsession",
+        return_value=mock_session,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_token_pairing"
+    assert result["errors"] == {"base": "pairing_failed"}
+
+
+async def test_ssdp_token_pairing_connection_error(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test token pairing shows error when HTTPS connection fails."""
+    mock_victron_hub.return_value.connect.side_effect = AuthenticationError(
+        "auth required"
+    )
+
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "X_MqttTokenPairing": "1",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["step_id"] == "ssdp_token_pairing"
+
+    mock_session = AsyncMock()
+    mock_session.post = AsyncMock(side_effect=aiohttp.ClientError("Connection refused"))
+
+    with patch(
+        "custom_components.victron_mqtt.config_flow.async_create_clientsession",
+        return_value=mock_session,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_token_pairing"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_ssdp_token_pairing_mqtt_connection_fails(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test token pairing shows error when credentials work but MQTT connect fails."""
+    mock_victron_hub.return_value.connect.side_effect = [
+        AuthenticationError("auth required"),
+        CannotConnectError("mqtt down"),
+    ]
+
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "X_MqttTokenPairing": "1",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["step_id"] == "ssdp_token_pairing"
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "token_name": "token/homeassistant/ha_abc",
+            "password": "secret",
+        }
+    )
+
+    mock_session = AsyncMock()
+    mock_session.post = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "custom_components.victron_mqtt.config_flow.async_create_clientsession",
+        return_value=mock_session,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_token_pairing"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_ssdp_no_token_pairing_falls_back_to_manual_auth(
+    hass: HomeAssistant, mock_victron_hub: MagicMock
+) -> None:
+    """Test SSDP without X_MqttTokenPairing routes to manual auth on auth error."""
+    mock_victron_hub.return_value.connect.side_effect = AuthenticationError(
+        "auth required"
+    )
+
+    discovery_info = SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="upnp:rootdevice",
+        ssdp_location="http://192.168.1.100:80/",
+        upnp={
+            "serialNumber": MOCK_SERIAL,
+            "X_VrmPortalId": MOCK_INSTALLATION_ID,
+            "modelName": MOCK_MODEL,
+            "friendlyName": MOCK_FRIENDLY_NAME,
+            "X_MqttOnLan": "1",
+            "manufacturer": "Victron Energy",
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=discovery_info,
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "ssdp_auth"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiohttp
 import pytest
 from custom_components.victron_mqtt._vendor.victron_mqtt import CannotConnectError, OperationMode
 from custom_components.victron_mqtt._vendor.victron_mqtt.pairing import PairingError, PairingToken
@@ -1299,7 +1298,7 @@ async def test_ssdp_token_pairing_connection_error(
 
     with patch(
         "custom_components.victron_mqtt.config_flow.request_pairing_token",
-        side_effect=aiohttp.ClientError("Connection refused"),
+        side_effect=ConnectionError("Connection refused"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
- Add SSDP detection of `X_MqttTokenPairing` from GX device discovery
- Add automatic token pairing flow: when a GX device advertises token pairing support, retrieve MQTT credentials via HTTPS POST to `/auth/generate-token/` instead of prompting for manual password entry
- Show pairing instructions in the UI, prompting the user to enable pairing mode on the GX device before submitting
- Try SSL (port 8883) first during SSDP discovery, fall back to plain MQTT (port 1883) if unavailable
- Simplify SSDP auth form: hardcode username to `remoteconsole`, rename password field to "GX Password", default SSL to on
- Add second SSDP matcher for `X_MqttTokenPairing=1` so discovery triggers even when `X_MqttOnLan` is disabled; issuing a token automatically enables "Paired devices only" access on the GX
- Add PairingError exception and pairing_failed error string
- Add `CONF_MQTT_TOKEN_PAIRING` constant, stored in config entry data when token pairing is used
- Add translations for all new UI elements in `en`, `de`, `fr`, `ca`, `sk`
- Add tests for token pairing success, HTTP error, connection error, MQTT validation failure, and fallback to manual auth

Note: The translations for `fr`, `ca`, and `sk` were generated automatically and should be reviewed.